### PR TITLE
Solve issue #3, should always transform image, regardless of iOS version.

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -47,31 +47,19 @@
 // The image will be scaled disproportionately if necessary to fit the bounds specified by the parameter
 - (UIImage *)resizedImage:(CGSize)newSize interpolationQuality:(CGInterpolationQuality)quality {
     BOOL drawTransposed;
-    CGAffineTransform transform = CGAffineTransformIdentity;
-    
-    // In iOS 5 the image is already correctly rotated. See Eran Sandler's
-    // addition here: http://eran.sandler.co.il/2011/11/07/uiimage-in-ios-5-orientation-and-resize/
-    
-    if ( [[[UIDevice currentDevice] systemVersion] floatValue] >= 5.0 ) 
+    switch ( self.imageOrientation )
     {
-        drawTransposed = NO;  
-    } 
-    else 
-    {    
-        switch ( self.imageOrientation ) 
-        {
-            case UIImageOrientationLeft:
-            case UIImageOrientationLeftMirrored:
-            case UIImageOrientationRight:
-            case UIImageOrientationRightMirrored:
-                drawTransposed = YES;
-                break;
-            default:
-                drawTransposed = NO;
-        }
+        case UIImageOrientationLeft:
+        case UIImageOrientationLeftMirrored:
+        case UIImageOrientationRight:
+        case UIImageOrientationRightMirrored:
+	    drawTransposed = YES;
+	    break;
+        default:
+	    drawTransposed = NO;
+    }
         
-        transform = [self transformForOrientation:newSize];
-    } 
+    CGAffineTransform transform = [self transformForOrientation:newSize];
     
     return [self resizedImage:newSize transform:transform drawTransposed:drawTransposed interpolationQuality:quality];
 }


### PR DESCRIPTION
Issue link: https://github.com/mbcharbonneau/UIImage-Categories/issues/3
