### PR TITLE
iOS 5 compatibility

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -120,13 +120,15 @@
     // images. See here: http://vocaro.com/trevor/blog/2009/10/12/resize-a-uiimage-the-right-way/comment-page-2/#comment-39951
         
 	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef bitmap =CGBitmapContextCreate( NULL,
-                                               newRect.size.width,
-                                               newRect.size.height,
-                                               8,
-                                               0,
-                                               colorSpace,
-                                               kCGImageAlphaPremultipliedLast );
+    CGContextRef bitmap = CGBitmapContextCreate(
+                                                NULL,
+                                                newRect.size.width,
+                                                newRect.size.height,
+                                                8, /* bits per channel */
+                                                (newRect.size.width * 4), /* 4 channels per pixel * numPixels/row */
+                                                CGColorSpaceCreateDeviceRGB(),
+                                                kCGImageAlphaPremultipliedLast
+                                                );
     CGColorSpaceRelease(colorSpace);
 	
     // Rotate and/or flip the image if required by its orientation


### PR DESCRIPTION
Makes it compatible with iOS 5.0 and fixes error "CGBitmapContextCreate: unsupported parameter combination: 8 integer bits/component; 32 bits/pixel; 3-component color space; kCGImageAlphaLast; 416 bytes/row.".
