### PR TITLE
Non-square thumbnails

### DIFF
--- a/UIImage+Resize.h
+++ b/UIImage+Resize.h
@@ -6,6 +6,10 @@
 // Extends the UIImage class to support resizing/cropping
 @interface UIImage (Resize)
 - (UIImage *)croppedImage:(CGRect)bounds;
+- (UIImage *)thumbnailSize:(CGSize)thumbnailSize
+          transparentBorder:(NSUInteger)borderSize
+               cornerRadius:(NSUInteger)cornerRadius
+       interpolationQuality:(CGInterpolationQuality)quality;
 - (UIImage *)thumbnailImage:(NSInteger)thumbnailSize
           transparentBorder:(NSUInteger)borderSize
                cornerRadius:(NSUInteger)cornerRadius

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -121,7 +121,7 @@
                                                8,
                                                0,
                                                colorSpace,
-                                               kCGImageAlphaPremultipliedLast );
+                                               (CGBitmapInfo)kCGImageAlphaPremultipliedLast );
     CGColorSpaceRelease(colorSpace);
 	
     // Rotate and/or flip the image if required by its orientation

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -19,23 +19,30 @@
     return croppedImage;
 }
 
-// Returns a copy of this image that is squared to the thumbnail size.
-// If transparentBorder is non-zero, a transparent border of the given size will be added around the edges of the thumbnail. (Adding a transparent border of at least one pixel in size has the side-effect of antialiasing the edges of the image when rotating it using Core Animation.)
 - (UIImage *)thumbnailImage:(NSInteger)thumbnailSize
           transparentBorder:(NSUInteger)borderSize
                cornerRadius:(NSUInteger)cornerRadius
        interpolationQuality:(CGInterpolationQuality)quality {
+    return [self thumbnailSize:CGSizeMake(thumbnailSize, thumbnailSize) transparentBorder:borderSize cornerRadius:cornerRadius interpolationQuality:quality];
+}
+
+// Returns a copy of this image that is squared to the thumbnail size.
+// If transparentBorder is non-zero, a transparent border of the given size will be added around the edges of the thumbnail. (Adding a transparent border of at least one pixel in size has the side-effect of antialiasing the edges of the image when rotating it using Core Animation.)
+- (UIImage *)thumbnailSize:(CGSize)thumbnailSize
+          transparentBorder:(NSUInteger)borderSize
+               cornerRadius:(NSUInteger)cornerRadius
+       interpolationQuality:(CGInterpolationQuality)quality {
     UIImage *resizedImage = [self resizedImageWithContentMode:UIViewContentModeScaleAspectFill
-                                                       bounds:CGSizeMake(thumbnailSize, thumbnailSize)
+                                                       bounds:thumbnailSize
                                          interpolationQuality:quality];
     
     // Crop out any part of the image that's larger than the thumbnail size
     // The cropped rect must be centered on the resized image
     // Round the origin points so that the size isn't altered when CGRectIntegral is later invoked
-    CGRect cropRect = CGRectMake(round((resizedImage.size.width - thumbnailSize) / 2),
-                                 round((resizedImage.size.height - thumbnailSize) / 2),
-                                 thumbnailSize,
-                                 thumbnailSize);
+    CGRect cropRect = CGRectMake(round((resizedImage.size.width - thumbnailSize.width) / 2),
+                                 round((resizedImage.size.height - thumbnailSize.height) / 2),
+                                 thumbnailSize.width,
+                                 thumbnailSize.height);
     UIImage *croppedImage = [resizedImage croppedImage:cropRect];
     
     UIImage *transparentBorderImage = borderSize ? [croppedImage transparentBorderImage:borderSize] : croppedImage;


### PR DESCRIPTION
add `thumbnailSize:transparentBorder:cornerRadius:interpolationQuality` which can create non-square thumbnails