### PR TITLE
Leak in the use of CGBitmapContextCreate.

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -119,7 +119,7 @@
                                                 newRect.size.height,
                                                 8, /* bits per channel */
                                                 (newRect.size.width * 4), /* 4 channels per pixel * numPixels/row */
-                                                CGColorSpaceCreateDeviceRGB(),
+                                                colorSpace,
                                                 kCGImageAlphaPremultipliedLast
                                                 );
     CGColorSpaceRelease(colorSpace);


### PR DESCRIPTION
colorSpace is allocated and released, but never used.  Instead, a separate call of "CGColorSpaceCreateDeviceRGB()" is used as an argument to "CGBitmapContextCreate" and never released.

This one line change fixes the leak.
