### PR TITLE
kCGImageAlphaPremultipliedLast Fix

### DIFF
--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -120,7 +120,7 @@
                                                 8, /* bits per channel */
                                                 (newRect.size.width * 4), /* 4 channels per pixel * numPixels/row */
                                                 colorSpace,
-                                                kCGImageAlphaPremultipliedLast
+                                                kCGBitmapAlphaInfoMask & kCGImageAlphaPremultipliedLast
                                                 );
     CGColorSpaceRelease(colorSpace);
 	


### PR DESCRIPTION
Changes the type of the last argument to a call to CGBitmapContextCreate
(without changing the actual value passed in the argument) to silence
a compiler warning in Xcode 5.