### PR TITLE
Fixed compilation issues when UIKit is not specified in precompiled headers.

### DIFF
--- a/UIImage+Alpha.h
+++ b/UIImage+Alpha.h
@@ -3,6 +3,8 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
 // Helper methods for adding an alpha layer to an image
 @interface UIImage (Alpha)
 - (BOOL)hasAlpha;

--- a/UIImage+Resize.h
+++ b/UIImage+Resize.h
@@ -3,6 +3,8 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
 // Extends the UIImage class to support resizing/cropping
 @interface UIImage (Resize)
 - (UIImage *)croppedImage:(CGRect)bounds;

--- a/UIImage+Resize.m
+++ b/UIImage+Resize.m
@@ -86,7 +86,7 @@
             break;
             
         default:
-            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %d", contentMode];
+            [NSException raise:NSInvalidArgumentException format:@"Unsupported content mode: %d", (int)contentMode];
     }
     
     CGSize newSize = CGSizeMake(self.size.width * ratio, self.size.height * ratio);
@@ -120,7 +120,7 @@
                                                 8, /* bits per channel */
                                                 (newRect.size.width * 4), /* 4 channels per pixel * numPixels/row */
                                                 colorSpace,
-                                                kCGImageAlphaPremultipliedLast
+                                                (CGBitmapInfo)kCGImageAlphaPremultipliedLast
                                                 );
     CGColorSpaceRelease(colorSpace);
 	
@@ -149,6 +149,11 @@
     CGAffineTransform transform = CGAffineTransformIdentity;
     
     switch (self.imageOrientation) {
+        case UIImageOrientationUp:
+        case UIImageOrientationUpMirrored:
+            //  Nothing to transform.
+            break;
+            
         case UIImageOrientationDown:           // EXIF = 3
         case UIImageOrientationDownMirrored:   // EXIF = 4
             transform = CGAffineTransformTranslate(transform, newSize.width, newSize.height);
@@ -171,6 +176,13 @@
     }
     
     switch (self.imageOrientation) {
+        case UIImageOrientationUp:
+        case UIImageOrientationLeft:
+        case UIImageOrientationDown:
+        case UIImageOrientationRight:
+            //  Nothing to transform.
+            break;
+            
         case UIImageOrientationUpMirrored:     // EXIF = 2
         case UIImageOrientationDownMirrored:   // EXIF = 4
             transform = CGAffineTransformTranslate(transform, newSize.width, 0);

--- a/UIImage+RoundedCorner.h
+++ b/UIImage+RoundedCorner.h
@@ -3,6 +3,8 @@
 // Free for personal or commercial use, with or without modification.
 // No warranty is expressed or implied.
 
+#import <UIKit/UIKit.h>
+
 // Extends the UIImage class to support making rounded corners
 @interface UIImage (RoundedCorner)
 - (UIImage *)roundedCornerImage:(NSInteger)cornerSize borderSize:(NSInteger)borderSize;


### PR DESCRIPTION
Fixed two compilation warnings with implicit conversions.
For clarity's sake added back explicit empty handling of orientation during in transformForOrientation.
