### PR TITLE
Carthage crash on launch fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xcuserstate
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM

--- a/UIImage-Categories.xcodeproj/project.pbxproj
+++ b/UIImage-Categories.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mbcharbonneau.UIImageCategories;
 				PRODUCT_NAME = UIImageCategories;
 				SKIP_INSTALL = YES;
 			};
@@ -290,7 +290,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mbcharbonneau.UIImageCategories;
 				PRODUCT_NAME = UIImageCategories;
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
Because of missing bundle identifier UIImageCategories library including via Carthage causes crash on start with error Domain = LaunchServicesError, Code = 0.